### PR TITLE
Build package with a workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,20 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - release
+
+jobs:
+  build-and-push-package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build and publish
+        uses: oc-ulos/upt-packager@release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,3 +18,6 @@ jobs:
 
       - name: Build and publish
         uses: oc-ulos/upt-packager@release
+        with:
+          repo: core
+          pkgname: coreutils

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          path: source
 
       - name: Build and publish
         uses: oc-ulos/upt-packager@release
         with:
           repo: core
           pkgname: coreutils
+          push_url: ${{ secrets.package_push_url }}/core
+          push_identity: ${{ secrets.package_push_identity }}


### PR DESCRIPTION
This branch sets up a workflow that uses the action in https://github.com/oc-ulos/upt-packager/pull/1 to build packages when there's a push to the release branch.

This workflow depends on some secrets, which would presumably be set on the oc-ulos org.
- `package_push_url` - e.g. `user@server:/path/to/packages`
- `package_push_identity` - SSH private key with no password. Ideally, this would be configured to be able to run scp only on the host.

cc @Ocawesome101 